### PR TITLE
bump version and point out to uninstall previous Earthly plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Check the currently released versions [on the JetBrains Marketplace](https://plu
 
 ## Known Issues
 
+### Uninstall Earthly plugin first!
+
+Please uninstall the now unsupported Earthly plugin first before installing the EarthBuild plugin.
+
 ### TextMate API Warnings
 The plugin uses TextMate APIs that are marked as deprecated in IntelliJ 2025.1.x. These warnings are expected and don't affect functionality. The APIs will be migrated when:
 - The new TextMate API is properly documented

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ intellijPlatform {
     pluginConfiguration {
         ideaVersion {
             sinceBuild = "232"
-            untilBuild = "251.*"
+            untilBuild = "252.*"
         }
     }
     


### PR DESCRIPTION
I ran into install issues unless I had uninstalled Earthly plugin.

RustRover's on 252. 