### PR TITLE
Bump untilBuild to 253.* for JetBrains 2025.3 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,16 @@ All notable changes to the EarthBuild IntelliJ Plugin will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.2] - 2025-08-01
+## [1.0.2] - 2026-04-22
+
+### Changed
+
+- Bumped `untilBuild` from `252.*` to `253.*` so the plugin remains available on
+  JetBrains IDE 2025.3 (platform build 253). Without this, the JetBrains
+  Marketplace hides the plugin from users upgrading to 253.
 
 ### Added
+
 - Enhanced plugin description with comprehensive feature documentation
 - Detailed change notes embedded in plugin.xml for better marketplace presentation
 - Demo Earthfile for documentation and taking screenshots
@@ -16,11 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.1] - 2025-08-01
 
 ### Fixed
+
 - Resolved version conflict for marketplace upload
 - Fixed 7 warnings about optional plugin dependencies by adding proper config-file attributes
 - Added Kotlin plugin compatibility mode support (K1 and K2)
 
 ### Added
+
 - Configuration files for optional dependencies:
   - Java integration (`earthly-java.xml`)
   - Kotlin integration (`earthly-kotlin.xml`)
@@ -32,35 +41,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0] - 2025-07-31
 
 ### Added
+
 - Full support for IntelliJ Platform 2025.1.3
 - Support for IntelliJ Platform builds 232 through 251.*
 - Migrated to IntelliJ Platform Gradle Plugin 2.6.0
 - Community fork of the original Earthly organization plugin
 
 ### Changed
+
 - Updated minimum IntelliJ version to 2023.2 (build 232)
 - Migrated from deprecated IntelliJ Platform Plugin 1.x to 2.x
 - Updated test infrastructure for compatibility with new platform APIs
 - Adjusted PSI output format to match IntelliJ 2025.1.3 changes
 
 ### Fixed
+
 - Parser tests now compatible with new TextMate scope format
 - Resolved all compilation warnings except TextMate API deprecations (non-blocking)
 - Fixed StringUtils deprecation by migrating to IntelliJ's StringUtil
 
 ### Known Issues
+
 - TextMate API deprecation warnings (functionality not affected)
 - These will be addressed in a future release when the new TextMate API stabilizes
 
 ## [Pre-1.0.0]
 
 ### Original Features (from Earthly organization)
+
 - Earthfile syntax highlighting via TextMate grammar
 - Go to definition for targets and functions
 - Find usages for targets and functions
 - Code completion for target and function references
 - Comment/uncomment support
-- File type recognition (Earthfile, *.earth, *.earthly)
+- File type recognition (Earthfile, *.earth,*.earthly)
 - Basic refactoring support (safe delete)
 
 ---

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ intellijPlatform {
     pluginConfiguration {
         ideaVersion {
             sinceBuild = "232"
-            untilBuild = "252.*"
+            untilBuild = "253.*"
         }
     }
 


### PR DESCRIPTION
## Summary

- Bump `untilBuild` from `252.*` to `253.*` in `build.gradle.kts` so the plugin stays listed on JetBrains IDE 2025.3 (platform build 253)
- Add changelog entry under the (previously unreleased) `1.0.2` section

## Why

JetBrains Marketplace notified that the current pin would hide the plugin from users upgrading to 253:

> JetBrains will soon release 253 IDE version. Currently, a limited `until-build` setting will prevent the following plugins from being available in this new release: EarthBuild

## Test plan

- [x] `earthly +test --version=1.0.2` passes (run locally, macOS arm64)
- [ ] After merge, tag `v1.0.2` to trigger `.github/workflows/ci-tag.yml` which signs and publishes to the marketplace

🤖 Generated with [Claude Code](https://claude.com/claude-code)